### PR TITLE
fix: make handleUpdate work properly with React batched updates

### DIFF
--- a/src/components/LazyLog/index.tsx
+++ b/src/components/LazyLog/index.tsx
@@ -488,28 +488,31 @@ export default class LazyLog extends Component<LazyLogProps, LazyLogState> {
 
     handleUpdate = ({ lines: moreLines, encodedLog }: any) => {
         this.encodedLog = encodedLog;
-        const { scrollToLine, follow, stream, websocket } = this.props;
-        const { count: previousCount } = this.state;
+        this.setState((state, props) => {
+            const { scrollToLine, follow } = props;
+            const { count: previousCount } = state;
 
-        const offset = 0;
-        const lines = (this.state.lines || List()).concat(moreLines);
-        const count = lines.count();
+            const offset = 0;
+            const lines = (state.lines || List()).concat(moreLines);
+            const count = lines.count();
 
-        const scrollToIndex = getScrollIndex({
-            follow,
-            scrollToLine,
-            previousCount,
-            count,
-            offset,
+            const scrollToIndex = getScrollIndex({
+                follow,
+                scrollToLine,
+                previousCount,
+                count,
+                offset,
+            });
+
+           return {
+               lines,
+               offset,
+               count,
+               scrollToIndex,
+           }
         });
 
-        this.setState({
-            lines,
-            offset,
-            count,
-            scrollToIndex,
-        });
-
+        const { stream, websocket } = this.props;
         if (stream || websocket) {
             this.forceSearch();
         }


### PR DESCRIPTION
It was noticed that `LazyLog` does not work properly with websockets on recent React versions.

My websocket is sending multiple messages immediately after the connection is opened. Yet I observed only the first and the last message rendered in the component.

I tracked it down to `handleUpdate`:
- it takes the previous state from `this.state`
- calculates the new state
- sets the new state with `this.setState`

However, as mentioned in the pitfall section of the [`setState` documentation](https://react.dev/reference/react/Component#setstate), `this.setState` does not update the state immediately. So most of the `handleUpdate` calls were getting an outdated state.

The PR fixes this by moving most of the `handleUpdate` code into a `this.setState` callback.