### PR TITLE
Added automatic reconnect to WebSocket

### DIFF
--- a/src/components/LazyLog/index.tsx
+++ b/src/components/LazyLog/index.tsx
@@ -39,6 +39,15 @@ export interface WebsocketOptions {
      * Callback allback which formats the websocket data stream.
      */
     formatMessage?: ((message: any) => string) | undefined;
+    /**
+     * Set to true, to reconnect the WebSocket automatically.
+     */
+    reconnect?: boolean;
+    /**
+     * Set the time to wait between reconnects in seconds.
+     * Default is 1s
+     */
+    reconnectWait?: number
 }
 
 export interface ErrorStatus extends Error {


### PR DESCRIPTION
Added `reconnect` and `reconnectWait` properties to the `WebsocketOptions`.

When `reconnect` is true and the Websocket disconnects, it will attempt a reconnect after `reconnectWait` seconds.

The props are optional. If not set, the behavior is unchanged.