### PR TITLE
fix a bug with the follow and extraLine parameters

### DIFF
--- a/src/components/LazyLog/index.tsx
+++ b/src/components/LazyLog/index.tsx
@@ -478,7 +478,7 @@ export default class LazyLog extends Component<LazyLogProps, LazyLogState> {
         // If follow is activated, and we're not currently searching, scroll to offset
         if (this.props.follow && !this.state.isSearching) {
             this.state.listRef?.current?.scrollToItem(
-                this.state.scrollToIndex,
+                this.state.scrollToIndex + (this.props?.extraLines || 0),
                 "auto"
             );
         }
@@ -1181,7 +1181,7 @@ export default class LazyLog extends Component<LazyLogProps, LazyLogState> {
                     />
                 )}
 
-                {/* 
+                {/*
                  // @ts-ignore */}
                 <AutoSizer
                     disableHeight={this.props.height !== "auto"}
@@ -1232,7 +1232,7 @@ export default class LazyLog extends Component<LazyLogProps, LazyLogState> {
                                     }
                                 }}
                             >
-                                {/* 
+                                {/*
                                  // @ts-ignore */}
                                 {this.renderRow}
                             </VariableSizeList>


### PR DESCRIPTION
Fix #53

In this PR, I added the `extraLines` parameter to the `scrollToLine` parameter when `follow` is activated. 
This change makes the data output more beautiful and solves the following problem:
When I use the `extraLines` parameter with `follow`, the `ScrollFollow` component cannot correctly calculates the values on line [78](https://github.com/melloware/react-logviewer/blob/main/src/components/ScrollFollow/index.tsx#L72), because "ScrollFollow" does not scroll to the last line, but the condition waits for the last line.