### PR TITLE
Fix line heights for when links are on and line wrapping is off

### DIFF
--- a/src/components/LinePart/index.module.css
+++ b/src/components/LinePart/index.module.css
@@ -8,6 +8,10 @@
     display: inline-block;
 }
 
+.noWrapLine {
+    display: ruby;
+}
+
 .black { color: #4e4e4e; }
 .red { color: #ff6c60; }
 .green { color: #00aa00; }

--- a/src/components/LinePart/index.module.css.d.ts
+++ b/src/components/LinePart/index.module.css.d.ts
@@ -30,6 +30,8 @@ declare namespace IndexModuleCssNamespace {
     yellow: string;
     yellowBg: string;
     yellowBold: string;
+    wrapLine: string;
+    noWrapLine: string;
   }
 }
 

--- a/src/components/LinePart/index.tsx
+++ b/src/components/LinePart/index.tsx
@@ -28,6 +28,8 @@ const getClassName = (part: LinePartCss, wrapLines: boolean) => {
 
     if (wrapLines) {
         className.push(styles.wrapLine);
+    } else {
+        className.push(styles.noWrapLine);
     }
 
     if (part.background) {


### PR DESCRIPTION
Never thought i'd find a use case for `display: ruby` but the stars have aligned.

Fixes line heights for then links are on and line wrapping is off

Before
![384538196-7440689c-0a18-4d1d-a997-41c54c594c58](https://github.com/user-attachments/assets/67b45e9c-e114-40aa-a3dd-b67b22f49958)

After:
<img width="707" alt="Screenshot 2024-11-08 at 5 56 07 PM" src="https://github.com/user-attachments/assets/b65211ad-a238-4530-b5f8-ef953520489a">
