### PR TITLE
fix: update README's run storybook command on section "Development and Contributing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ own `LinePart` and styled separately (colors, text formatting, etc.) from the re
 
 -   Fork and clone this repo.
 -   Install the dependencies with `npm`.
--   Start the development server with `npm run dev`. This will launch a StoryBook instance.
+-   Start the development server with `npm run storybook`. This will launch a StoryBook instance.
     Open a browser to http://localhost:6006 to preview the React components.
 -   Use CTRL-C to exit the StoryBook.
 -   Use `npm run build` to generate the compiled component for publishing to npm.


### PR DESCRIPTION
## Description of change

- Updates README instruction to open storybook, from running script `dev` to `storybook`

## Why make this change

The current README.md guides the user to run command `npm run dev` to open storybook, but it opens vite

In #60 this script was renamed to `storybook` without updating the README

## More Info

![image](https://github.com/user-attachments/assets/acaffee0-6e4d-4c1f-995b-6077c213c50a)

https://github.com/melloware/react-logviewer/pull/60/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519