### PR TITLE
fix #62: include non-link results in `parseLinks` result

### DIFF
--- a/src/components/Utils/utils.ts
+++ b/src/components/Utils/utils.ts
@@ -259,9 +259,12 @@ export const parseLinks = (lines: any[]): LinePartCss[] => {
         const arr = line.text.split(" ");
 
         let found = false;
+        let partial = '';
 
         arr.forEach((text: string) => {
             if (text.search(strictUrlRegex) > -1) {
+                result.push({ text: partial.trimEnd() });
+                partial = '';
                 found = true;
                 const email = true;
                 const link = true;
@@ -285,6 +288,8 @@ export const parseLinks = (lines: any[]): LinePartCss[] => {
 
                 return;
             }
+
+            partial += text + ' ';
         });
 
         if (!found) {


### PR DESCRIPTION
## Description of change

- Updates `parseLinks` util to include non-link results

## Why make this change

Fixes #62

## More info

See line L1 on rendered Log

BEFORE:

![image](https://github.com/user-attachments/assets/bec63197-7ca2-4804-938f-8c7957927769)

```
https://www.mozilla.org/ http://www.mozilla.org
```

AFTER:

![image](https://github.com/user-attachments/assets/9db2566d-accc-4d9a-b487-6f68ee47967f)

```
Can be secure https://www.mozilla.org/ or unsecure http://www.mozilla.org
```