### PR TITLE
build: Reduce bundle size from unnecessary bundeling react/jsx-runtime in embed-react package

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,20 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+	plugins: [react()],
+	rollupOptions: {
+	  // make sure to externalize deps that shouldn't be bundled
+	  // into your library
+	  external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
+	  output: {
+		exports: "named",
+		// Provide global variables to use in the UMD build
+		// for externalized deps
+		globals: {
+		  react: "React",
+		  "react-dom": "ReactDOM",
+		},
+	  },
 })
+
+


### PR DESCRIPTION
Removes unnecessary bundeling of react stuff, reduces bundle size and fixes #67