### PR TITLE
Fix to remove trailing parenthesis from parsed `Link`

### DIFF
--- a/src/components/Utils/utils.test.ts
+++ b/src/components/Utils/utils.test.ts
@@ -1,0 +1,43 @@
+import { parseLinks } from "./utils";
+
+describe("Parsing lines with links", () => {
+  it("should be able to parse links wrapped in parentheses.", () => {
+    const lines = [
+      {
+        text: "(https://example.com)",
+      },
+    ];
+    const links = parseLinks(lines);
+    expect(links.length).toBe(4);
+    expect(links[0]?.text).toBeFalsy();
+    expect(links[1]?.text).toBe("(");
+    expect(links[2]?.text?.endsWith(")")).toBeFalsy();
+    expect(links[3]?.text).toBe(")");
+  });
+
+  it("should be able to parse links starting with a parenthesis.", () => {
+    const lines = [
+      {
+        text: "(https://example.com",
+      },
+    ];
+    const links = parseLinks(lines);
+    expect(links.length).toBe(3);
+    expect(links[0]?.text).toBeFalsy();
+    expect(links[1]?.text).toBe("(");
+    expect(links[2]?.text?.endsWith(")")).toBeFalsy();
+  });
+
+  it("should be able to parse links with a trailing parenthesis.", () => {
+    const lines = [
+      {
+        text: "https://example.com)",
+      },
+    ];
+    const links = parseLinks(lines);
+    expect(links.length).toBe(3);
+    expect(links[0]?.text).toBeFalsy();
+    expect(links[1]?.text?.endsWith(")")).toBeFalsy();
+    expect(links[2]?.text).toBe(")");
+  });
+});


### PR DESCRIPTION
Hello react-logviewer!

While trying to parse a `Link` wrapped in parentheses, I found that the trailing parenthesis ramains in the result.

For example, when I tried to parse `"(https://example.com)"`, it resulted in `["(", "https://example.com)"]`, which does not seem to be a valid URL.

Therefore, this pull request patches `parseLinks()` to consider trailing parenthesis, as well as starting parenthesis.

Refs
- https://github.com/pytorch/pytorch/blob/17e05cde0c405dad11a17bcdc0f85f941dcc6c94/c10/cuda/CUDACachingAllocator.cpp#L1338-L1363

--- Generated by copilot below ---

This pull request includes changes to the link parsing functionality in the `src/components/Utils/utils.ts` file and corresponding tests in the `src/components/Utils/utils.test.ts` file. The changes improve the handling of links wrapped in parentheses and ensure more accurate parsing of such links.

Improvements to link parsing:

* [`src/components/Utils/utils.ts`](diffhunk://#diff-60e66ee65f0671f6525cfe3c268bc0c56721d35643009219d0fb50ce20634f5fL265-R304): Updated the `parseLinks` function to handle links wrapped in parentheses by splitting tokens using a more precise regular expression and processing each part accordingly.

Testing enhancements:

* [`src/components/Utils/utils.test.ts`](diffhunk://#diff-cd1bf7fb01b13a5cb3c75c9fce318b9cb0c044f8180bc0cebb914ba09b2b0021R1-R43): Added new test cases to verify the correct parsing of links wrapped in parentheses, links starting with a parenthesis, and links with a trailing parenthesis.
